### PR TITLE
Update enums and fix tables

### DIFF
--- a/docs/cdoc/exit-codes.rst
+++ b/docs/cdoc/exit-codes.rst
@@ -2,10 +2,39 @@
 Exit codes
 ==========
 
-This page documents the ``ExitCode`` enum.
+.. code-block:: c
 
-----------
-Data types
-----------
+    enum ExitCode
 
-.. doxygenenum:: ExitCode
+Function exit codes.
+
+Values
+------
+
+``QkExitCode_Success``
+    Success.
+        * Value: 0
+
+``QkExitCode_CInputError``
+    Error related to data input.
+        * Value: 100
+
+``QkExitCode_NullPointerError``
+    Unexpected null pointer.
+        * Value: 101
+
+``QkExitCode_AlignmentError``
+    Pointer is not aligned to expected data.
+        * Value: 102
+
+``QkExitCode_IndexError``
+    Index out of bounds.
+        * Value: 103
+
+``QkExitCode_ArithmeticError``
+    Error related to arithmetic operations or similar.
+        * Value: 200
+
+``QkExitCode_MismatchedQubits``
+    Mismatching number of qubits.
+        * Value: 201

--- a/docs/cdoc/qk-bit-term.rst
+++ b/docs/cdoc/qk-bit-term.rst
@@ -32,7 +32,7 @@ Values
       * Value: 10 (``0b1010``)
 
 ``QkBitTerm_Minus``
-   The projector :math:`\lvert -\rangle\langle -\rvert` to the negative :math:`X` eigenstate.]
+   The projector :math:`\lvert -\rangle\langle -\rvert` to the negative :math:`X` eigenstate.
       * Value: 6 (``0b0110``)
 
 ``QkBitTerm_Right``

--- a/docs/cdoc/qk-bit-term.rst
+++ b/docs/cdoc/qk-bit-term.rst
@@ -12,44 +12,44 @@ QkBitTerm
 
 An enum that to represent each of the single-qubit alphabet terms enumerated below. 
 
-Members
--------
+Values
+------
 
-* **enumerator QkBitTerm_X** 
-   Value: 2 (``0b0010``)
+``QkBitTerm_X`` 
    The Pauli :math:`X` operator. 
+      * Value: 2 (``0b0010``)
 
-* **enumerator QkBitTerm_Y**
-   Value: 3 (``0b0011``)
+``QkBitTerm_Y``
    The Pauli :math:`Y` operator.
+      * Value: 3 (``0b0011``)
 
-* **enumerator QkBitTerm_Z**
-   Value: 1 (``0b0001``)
+``QkBitTerm_Z``
    The Pauli :math:`Z` operator.
+      * Value: 1 (``0b0001``)
 
-* **enumerator QkBitTerm_Plus**
-   Value: 10 (``0b1010``)
+``QkBitTerm_Plus``
    The projector :math:`\lvert +\rangle\langle +\rvert` to the positive :math:`X` eigenstate.
+      * Value: 10 (``0b1010``)
 
-* **enumerator QkBitTerm_Minus**
-   Value: 6 (``0b0110``)
+``QkBitTerm_Minus``
    The projector :math:`\lvert -\rangle\langle -\rvert` to the negative :math:`X` eigenstate.]
+      * Value: 6 (``0b0110``)
 
-* **enumerator QkBitTerm_Right**
-   Value: 11 (``0b1011``)
+``QkBitTerm_Right``
    The projector :math:`\lvert r\rangle\langle r\rvert` to the positive :math:`Y` eigenstate.
+      * Value: 11 (``0b1011``)
 
-* **enumerator QkBitTerm_Left**
-   Value: 7 (``0b1011``)
+``QkBitTerm_Left``
    The projector :math:`\lvert l\rangle\langle l\rvert` to the negative :math:`Y` eigenstate.
+      * Value: 7 (``0b1011``)
 
-* **enumerator QkBitTerm_Zero**
-   Value: 9 (``0b1001``)
+``QkBitTerm_Zero``
    The projector :math:`\lvert 0\rangle\langle 0\rvert` to the positive :math:`Z` eigenstate.
+      * Value: 9 (``0b1001``)
 
-* **enumerator QkBitTerm_One**
-   Value: 5 (``0b0101``)
+``QkBitTerm_One``
    The projector :math:`\lvert 1\rangle\langle 1\rvert` to the negative :math:`Z` eigenstate.
+      * Value: 5 (``0b0101``)
 
 Representation
 --------------

--- a/docs/cdoc/qk-obs.rst
+++ b/docs/cdoc/qk-obs.rst
@@ -27,35 +27,35 @@ Pauli operators and the Pauli-eigenstate projection operators.  Explicitly, thes
 .. _sparse-observable-alphabet:
 .. table:: Alphabet of single-qubit terms used in ``QkObs``
 
-  =======================================  ==================  ===============
-  Operator                                 ``QkBitTerm``       Numeric value
-  =======================================  ==================  ===============
-  :math:`I` (identity)                     Not stored.         Not stored.
+  =======================================  ===================  ================
+  Operator                                 ``QkBitTerm``        Numeric value
+  =======================================  ===================  ================
+  :math:`I` (identity)                     Not stored.          Not stored.
 
-  :math:`X` (Pauli X)                      ``QkBitTerm_X``     ``0b0010`` (2)   
+  :math:`X` (Pauli X)                      ``QkBitTerm_X``      ``0b0010`` (2)   
 
-  :math:`Y` (Pauli Y)                      ``QkBitTerm_Y``     ``0b0011`` (3)   
+  :math:`Y` (Pauli Y)                      ``QkBitTerm_Y``      ``0b0011`` (3)   
 
-  :math:`Z` (Pauli Z)                      ``QkBitTerm_Z``     ``0b0001`` (1)   
+  :math:`Z` (Pauli Z)                      ``QkBitTerm_Z``      ``0b0001`` (1)   
 
-  :math:`\lvert+\rangle\langle+\rvert`     ``QkBitTerm_Plus``  ``0b1010`` (10)  
+  :math:`\lvert+\rangle\langle+\rvert`     ``QkBitTerm_Plus``   ``0b1010`` (10)  
   (projector to positive eigenstate of X)
 
-  :math:`\lvert-\rangle\langle-\rvert`     ``QkBitTerm_Minus`` ``0b0110`` (6)   
+  :math:`\lvert-\rangle\langle-\rvert`     ``QkBitTerm_Minus``  ``0b0110`` (6)   
   (projector to negative eigenstate of X)
 
-  :math:`\lvert r\rangle\langle r\rvert`   ``QkBitTerm_Right`` ``0b1011`` (11)  
+  :math:`\lvert r\rangle\langle r\rvert`   ``QkBitTerm_Right``  ``0b1011`` (11)  
   (projector to positive eigenstate of Y)
 
-  :math:`\lvert l\rangle\langle l\rvert`   ``QkBitTerm_Left``  ``0b0111`` (7)   
+  :math:`\lvert l\rangle\langle l\rvert`   ``QkBitTerm_Left``   ``0b0111`` (7)   
   (projector to negative eigenstate of Y)
 
-  :math:`\lvert0\rangle\langle0\rvert`     ``QkBitTerm_Zero``  ``0b1001`` (9)   
+  :math:`\lvert0\rangle\langle0\rvert`     ``QkBitTerm_Zero``   ``0b1001`` (9)   
   (projector to positive eigenstate of Z)
 
-  :math:`\lvert1\rangle\langle1\rvert`     ``QkBitTerm_One``   ``0b0101`` (5)   
+  :math:`\lvert1\rangle\langle1\rvert`     ``QkBitTerm_One``    ``0b0101`` (5)   
   (projector to negative eigenstate of Z)
-  =======================================  ==================  ===============
+  =======================================  ===================  ================
 
 Due to allowing both the Paulis and their projectors, the allowed alphabet forms an overcomplete
 basis of the operator space.  This means that there is not a unique summation to represent a
@@ -88,20 +88,23 @@ the representation is made up of four contiguous arrays:
 .. _sparse-observable-arrays:
 .. table:: Data arrays used to represent ``QkObs``
 
-  =======================  ===========  ========================================================
+  =======================  ===========  ============================================================
   Attribute accessible by  Length       Description
-  =======================  ===========  ========================================================
+  =======================  ===========  ============================================================
   ``qk_obs_coeffs``        :math:`t`    The complex scalar multiplier for each term.
+
   ``qk_obs_bit_terms``     :math:`s`    Each of the non-identity single-qubit terms for all of
                                         the operators, in order. These correspond to the
                                         non-identity :math:`A^{(n)}_i` in the sum description,
                                         where the entries are stored in order of increasing
                                         :math:`i` first, and in order of increasing :math:`n`
                                         within each term.
+
   ``qk_obs_indices``       :math:`s`    The corresponding qubit (:math:`n`) for each of the
                                         bit terms. ``QkObs`` requires that this list is term-wise
                                         sorted, and algorithms can rely on this invariant being
                                         upheld.
+
   ``qk_obs_boundaries``    :math:`t+1`  The indices that partition the bit terms and indices
                                         into complete terms.  For term number :math:`i`, its
                                         complex coefficient is stored at index ``i``, and its
@@ -110,7 +113,7 @@ the representation is made up of four contiguous arrays:
                                         in the bit terms and indices, respectively.
                                         The boundaries always have an explicit 0 as their first
                                         element.
-  =======================  ===========  ========================================================
+  =======================  ===========  ============================================================
 
 The length parameter :math:`t` is the number of terms in the sum and can be queried using
 ``qk_obs_num_terms``. The parameter :math:`s` is the total number of non-identity single-qubit
@@ -220,7 +223,9 @@ care to ensure the data is coherent and results in a valid observable.
   Function             Summary
   ===================  =========================================================================
   ``qk_obs_zero``      Construct an empty observable on a given number of qubits.
+
   ``qk_obs_identity``  Construct the identity observable on a given number of qubits.
+
   ``qk_obs_new``       Construct an observable from :ref:`the raw data arrays
                        <sparse-observable-arrays>`.
   ===================  =========================================================================

--- a/docs/cdoc/qk-obs.rst
+++ b/docs/cdoc/qk-obs.rst
@@ -69,7 +69,7 @@ observable :math:`{\lvert0\rangle\langle0\rvert}^{\otimes n}` can be efficiently
 hardware with simple :math:`Z` measurements, but can only be represented in terms of Paulis
 as :math:`{(I + Z)}^{\otimes n}/2^n`, which requires :math:`2^n` stored terms. ``QkObs`` requires 
 only a single term to store this. The downside to this is that it is impractical to take an 
-arbitrary matrix and find the *best*``QkObs`` representation.  You typically will want to construct 
+arbitrary matrix and find the *best* ``QkObs`` representation.  You typically will want to construct 
 a ``QkObs`` directly, rather than trying to decompose into one.
 
 
@@ -84,8 +84,10 @@ The terms are stored compressed, similar in spirit to the compressed sparse row 
 matrices.  In this analogy, the terms of the sum are the "rows", and the qubit terms are the
 "columns", where an absent entry represents the identity rather than a zero.  More explicitly,
 the representation is made up of four contiguous arrays:
+
 .. _sparse-observable-arrays:
 .. table:: Data arrays used to represent ``QkObs``
+
   =======================  ===========  ========================================================
   Attribute accessible by  Length       Description
   =======================  ===========  ========================================================
@@ -113,14 +115,16 @@ the representation is made up of four contiguous arrays:
 The length parameter :math:`t` is the number of terms in the sum and can be queried using
 ``qk_obs_num_terms``. The parameter :math:`s` is the total number of non-identity single-qubit
 terms and can be queried using ``qk_obs_len``.
+
 As illustrative examples:
+
 * in the case of a zero operator, the boundaries are length 1 (a single 0) and all other
   vectors are empty.
 * in the case of a fully simplified identity operator, the boundaries are ``{0, 0}``,
   the coefficients have a single entry, and both the bit terms and indices are empty.
 * for the operator :math:`Z_2 Z_0 - X_3 Y_1`, the boundaries are ``{0, 2, 4}``,
-  the coeffs are ``{1.0, -1.0}``, the bit terms are ``[BitTerm.Z, BitTerm.Z, BitTerm.Y,
-  BitTerm.X]`` and the indices are ``{0, 2, 1, 3}``.  The operator might act on more than
+  the coeffs are ``{1.0, -1.0}``, the bit terms are ``{BitTerm.Z, BitTerm.Z, BitTerm.Y,
+  BitTerm.X}`` and the indices are ``{0, 2, 1, 3}``.  The operator might act on more than
   four qubits, depending on the the number of qubits (see ``qk_obs_num_qubits``). Note
   that the single-bit terms and indices are sorted into termwise sorted order.  
 
@@ -227,6 +231,7 @@ Mathematical manipulation
 
 ``QkObs`` supports fundamental arithmetic operations in between observables or with scalars.
 You can:
+
 * add two observables using ``qk_obs_add``
 * multiply by a complex number with ``qk_obs_multiply``
 * compose (multiply) two observables via ``qk_obs_compose`` and ``qk_obs_compose_map``


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Format enums so they format as
```
``QkBitTerm_X``
    Description goes here.
    *  Value: value
```
this is a bit different than the current standard used e.g. for the `ExitCode` enum, but I think it's important we show the value. Maybe we can later on update how enums are formatted? Otherwise we could also manually document the `ExitCode` for now for a consistent look.

Also fix some errors in the tables and itemizations coming from missing spaces/linebreaks.


